### PR TITLE
Let guard exec run in dry-run

### DIFF
--- a/client/lib/etch/client.rb
+++ b/client/lib/etch/client.rb
@@ -2190,7 +2190,7 @@ class Etch::Client
 
     # Actually run the command unless we're in a dry run, or if we're in
     # a damp run and the command is a setup command.
-    if ! @dryrun || (@dryrun == 'damp' && exectype == 'setup')
+    if ! @dryrun || exectype == 'guard' || (@dryrun == 'damp' && exectype == 'setup')
       etch_priority = nil
 
       if exectype == 'post' || exectype == 'command'


### PR DESCRIPTION
Currently guard exec is not run in a dry run, and subsequently no command exec is mentioned during a dry run.
I understand the conservatism behind this, but I think it's better to let them run.
My justifications:
1. To make dry-run meaningful for configuration commands
2. Definitely safer than forcing users to skip dry-run
3. Guard exec is supposed to make no change
