### PR TITLE
Updating gemspec to deal with deprecation errors

### DIFF
--- a/client/packages/gem/gemspec
+++ b/client/packages/gem/gemspec
@@ -1,17 +1,16 @@
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 spec = Gem::Specification.new do |s|
-  s.name	= 'etch'
-  s.summary	= 'Etch system configuration management client'
+  s.name        = 'etch'
+  s.summary     = 'Etch system configuration management client'
   s.add_dependency('facter')
   s.version = '%VER%'
   s.author = 'Jason Heiss'
   s.email = 'etch-users@lists.sourceforge.net'
-  s.homepage = 'http://etch.sourceforge.net'
+  s.homepage = 'http://etch.github.io'
   s.rubyforge_project = 'etchsyscm'
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>=1.8'
-  s.files	= Dir['**/**']
+  s.files       = Dir['**/**']
   s.executables = [ 'etch', 'etch_to_trunk', 'etch_cron_wrapper' ]
 end
-Rake::GemPackageTask.new(spec).define
-
+Gem::PackageTask.new(spec).define


### PR DESCRIPTION
```
rake aborted!
ERROR: 'rake/gempackagetask' is obsolete and no longer supported. Use 'rubygems/package_task' instead.
```

also updating the homepage in the gemspec.
