### PR TITLE
Update json dependency to 1.8.5 for ruby >=2.4

### DIFF
--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     jquery-rails (3.1.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.5)
     libv8 (3.16.14.3)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)


### PR DESCRIPTION
Ruby 2.4 unified Fixnum and Bignum into Integer [1].  This causes issues
when running bundle, because bundler will fail when compiling native
extensions for json like so:

generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function); did you mean ‘mFixnum’?
  861 |     } else if (klass == rb_cFixnum) {
      |                         ^~~~~~~~~~
      |                         mFixnum

Setting the version of json to 1.8.5 includes the fix for this issue,
and allows etch server installability.

[1] https://bugs.ruby-lang.org/issues/12005